### PR TITLE
Fix local install compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "chrome-devtools-mcp": "^0.20.3",
-        "puppeteer-core": "^24.39.1",
-        "rebrowser-patches": "^1.0.19"
+        "chrome-devtools-mcp": "0.20.3",
+        "puppeteer-core": "24.39.1",
+        "rebrowser-patches": "1.0.19"
       },
       "bin": {
         "chrome-devtools-mcp-rebrowser": "launch.mjs"
@@ -601,9 +601,10 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.40.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
-      "integrity": "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==",
+      "version": "24.39.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.39.1.tgz",
+      "integrity": "sha512-AMqQIKoEhPS6CilDzw0Gd1brLri3emkC+1N2J6ZCCuY1Cglo56M63S0jOeBZDQlemOiRd686MYVMl9ELJBzN3A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.13.0",
         "chromium-bidi": "14.0.0",

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "start": "node launch.mjs"
   },
   "dependencies": {
-    "chrome-devtools-mcp": "^0.20.3",
-    "puppeteer-core": "^24.39.1",
-    "rebrowser-patches": "^1.0.19"
+    "chrome-devtools-mcp": "0.20.3",
+    "puppeteer-core": "24.39.1",
+    "rebrowser-patches": "1.0.19"
   },
   "publishConfig": {
     "access": "public"

--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -65,12 +65,65 @@ function stripHunksFromPatch(patchContent, filterRe) {
   for (const line of lines) {
     // Each file section starts with "--- a/..."
     if (line.startsWith('--- a/')) {
-      const path = line.slice('--- a/'.length);
+      const path = line.slice('--- a/'.length).trim();
       skipping = filterRe.test(path);
     }
     if (!skipping) kept.push(line);
   }
   return kept.join('\n');
+}
+
+async function insertBeforeMarker(filePath, marker, snippet) {
+  const content = await readFile(filePath, 'utf8');
+
+  if (content.includes(snippet.trim())) {
+    return;
+  }
+
+  const index = content.indexOf(marker);
+  if (index === -1) {
+    throw new Error(`Could not find patch marker in ${filePath}`);
+  }
+
+  const updated = content.slice(0, index) + snippet + content.slice(index);
+  await writeFile(filePath, updated);
+}
+
+async function applyBrowserConnectionPatch(puppeteerCoreDir) {
+  const jsSnippet =
+    "    // rebrowser-patches: expose browser CDP session\n" +
+    "    _connection() {\n" +
+    "        return this.#connection;\n" +
+    "    }\n";
+
+  const targets = [
+    {
+      filePath: join(puppeteerCoreDir, 'lib', 'cjs', 'puppeteer', 'cdp', 'Browser.d.ts'),
+      marker: '    _createPageInContext(',
+      snippet: '    _connection(): Connection;\n',
+    },
+    {
+      filePath: join(puppeteerCoreDir, 'lib', 'cjs', 'puppeteer', 'cdp', 'Browser.js'),
+      marker: '    async _createPageInContext(',
+      snippet: jsSnippet,
+    },
+    {
+      filePath: join(puppeteerCoreDir, 'lib', 'esm', 'puppeteer', 'cdp', 'Browser.d.ts'),
+      marker: '    _createPageInContext(',
+      snippet: '    _connection(): Connection;\n',
+    },
+    {
+      filePath: join(puppeteerCoreDir, 'lib', 'esm', 'puppeteer', 'cdp', 'Browser.js'),
+      marker: '    async _createPageInContext(',
+      snippet: jsSnippet,
+    },
+  ];
+
+  for (const target of targets) {
+    await insertBeforeMarker(target.filePath, target.marker, target.snippet);
+  }
+
+  console.log('✔ Applied Browser._connection() compatibility patch');
 }
 
 /**
@@ -108,8 +161,9 @@ async function applyPatch(patchBin, targetDir, patchFile, { fuzz } = {}) {
     // "already applied" situation.
     const hasFailedHunks = /FAILED/i.test(err.stdout);
     const hasReversed = /Reversed \(or previously applied\) patch detected/i.test(err.stdout);
+    const hasIgnored = /Ignoring previously applied \(or reversed\) patch/i.test(err.stdout);
 
-    if (hasReversed && !hasFailedHunks) {
+    if ((hasReversed || hasIgnored) && !hasFailedHunks) {
       console.log(`✔ Patch already applied in ${targetDir} (skipped)`);
       return;
     }
@@ -148,8 +202,9 @@ async function main() {
   // 3. Apply rebrowser-patches to puppeteer-core (with fuzz for version tolerance)
   //    The upstream patch includes hunks for lib/es5-iife/ which is a bundled
   //    build that doesn't exist in every puppeteer-core release and doesn't
-  //    affect Node-side behaviour.  We strip those hunks so they can't cause
-  //    spurious failures.
+  //    affect Node-side behaviour. The Browser.* hunks are also stripped and
+  //    applied separately because their surrounding context changes across
+  //    patch-compatible Puppeteer releases.
   const rebrowserPatchFile = join(
     rebrowserPatchesDir,
     'patches',
@@ -158,7 +213,10 @@ async function main() {
   );
 
   const rawPatch = await readFile(rebrowserPatchFile, 'utf8');
-  const filteredPatch = stripHunksFromPatch(rawPatch, /^lib\/es5-iife\//);
+  const filteredPatch = stripHunksFromPatch(
+    rawPatch,
+    /^lib\/es5-iife\/|^lib\/(?:cjs|esm)\/puppeteer\/cdp\/Browser\.(?:d\.ts|js)$/,
+  );
 
   // Write the filtered patch to a temp file
   const tmpDir = await mkdtemp(join(tmpdir(), 'rebrowser-'));
@@ -168,6 +226,7 @@ async function main() {
   try {
     console.log('--- Applying rebrowser-patches to puppeteer-core (es5-iife stripped) ---');
     await applyPatch(patchBin, puppeteerCoreDir, filteredPatchFile, { fuzz: 10 });
+    await applyBrowserConnectionPatch(puppeteerCoreDir);
   } finally {
     // Clean up temp file
     await unlink(filteredPatchFile).catch(() => {});


### PR DESCRIPTION

  修复 rebrowser 补丁的本地安装兼容性问题 #1 
  ## 变更说明

  这个 PR 修复了 `rebrowser-patches` 集成在本地安装时容易失败的问题。

  ## 主要修改

  - 在 `package.json` 中将依赖版本固定到已验证兼容的版本
  - 同步更新 `package-lock.json`
  - 增强 `postinstall.mjs` 的补丁应用逻辑
  - 将上游补丁中容易因上下文变化而失败的 `Browser.*` hunk 排除，改为单独应用 `_connection()` 兼容补丁
  - 在解析 patch 路径时增加 `trim` 处理，避免路径匹配失败
  - 更稳妥地识别“补丁已应用”的情况，避免误判为安装失败

  ## 修改原因

  当前安装流程里，`npm install` 可能因为以下原因失败：

  - `puppeteer-core` 被解析到一个小版本差异但不兼容的版本
  - `rebrowser-patches` 上游 patch 的上下文与当前依赖文件存在轻微偏移，导致 `patch` 命令拒绝部分 hunk

  这次修改的目标是让安装过程更稳定、可复现，同时保持原有功能不变。

  ## 验证结果

  已完成以下验证：

  - `npm install` 可以成功执行
  - `node launch.mjs --help` 可以正常执行
  - 使用 `--auto-connect` 可以成功启动 MCP 服务
  - 日志中确认出现 `Chrome DevTools MCP Server connected`

  ## 备注

  这次修改不涉及功能裁剪，也没有去掉原有的 MCP 能力或 rebrowser 反检测逻辑，属于安装兼容性和稳定性修复。
